### PR TITLE
Refactoring subscriber concept

### DIFF
--- a/__tests__/Broadcast.spec.ts
+++ b/__tests__/Broadcast.spec.ts
@@ -8,7 +8,7 @@ describe('Messenger', () => {
   }))
 
   const Subscriber = jest.fn<Subscriber, []>(() => ({
-    identifier: jest.fn(),
+    uid: jest.fn(),
     inbound: jest.fn(),
   }))
 

--- a/src/MessagingContracts.ts
+++ b/src/MessagingContracts.ts
@@ -12,7 +12,7 @@ export declare type MessageShape<PayloadShape> = {
  *
  */
 export interface Subscriber {
-  identifier(): string
+  uid(): string
   inbound(): string
 }
 

--- a/src/Transports/Firestore.ts
+++ b/src/Transports/Firestore.ts
@@ -23,7 +23,7 @@ export default class Firestore
   ) {}
 
   async grant(
-    subscriberId: string,
+    uid: string,
     privateChannels: string[],
   ): Promise<JWTGrantedEntity> {
     // We'll use the custom token mechanism from Firebase to
@@ -34,7 +34,7 @@ export default class Firestore
     const claims = {
       privateChannels,
     }
-    const token = await this.auth.createCustomToken(subscriberId, claims)
+    const token = await this.auth.createCustomToken(uid, claims)
 
     return {
       token,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "declarationDir": "./types",
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
-    "target": "ESNext",
+    "target": "ES2018",
     "sourceMap": true,
     "module": "CommonJS",
     "moduleResolution": "node",


### PR DESCRIPTION
Fixes *Wrong build target for NodeJS*

Changes:

- Using changing `Subscriber.identifier()` function signature to `Subscriber.uid()`
